### PR TITLE
Add insight cards with graph and stats

### DIFF
--- a/index.html
+++ b/index.html
@@ -264,6 +264,25 @@
             border-color: var(--accent-color);
         }
 
+        .insight-cards {
+            display: flex;
+            flex-direction: column;
+            gap: 20px;
+            margin-top: 20px;
+        }
+
+        .insight-card {
+            background-color: #24244a;
+            padding: 15px;
+            border-radius: 8px;
+            box-shadow: 0 4px 15px rgba(0, 0, 0, 0.2);
+        }
+
+        #pathGraph {
+            width: 100%;
+            height: 200px;
+        }
+
     </style>
 </head>
 <body>
@@ -289,6 +308,18 @@
         </div>
         <div id="errorMessage" class="error-message"></div>
 
+        <div class="insight-cards">
+            <div class="insight-card">
+                <h3>Sequence Stats</h3>
+                <p id="totalSteps">Total steps: -</p>
+                <p id="maxNumber">Max number: -</p>
+            </div>
+            <div class="insight-card">
+                <h3>Path Graph</h3>
+                <canvas id="pathGraph"></canvas>
+            </div>
+        </div>
+
         <h2 id="knownNumbersHeader">Known Numbers (Session)</h2>
         <div id="knownNumbersDisplayArea">
             <!-- Clickable known numbers will be displayed here -->
@@ -306,6 +337,11 @@
         const errorMessage = document.getElementById('errorMessage');
         const knownNumbersHeader = document.getElementById('knownNumbersHeader');
         const knownNumbersDisplayArea = document.getElementById('knownNumbersDisplayArea');
+        const totalStepsElem = document.getElementById('totalSteps');
+        const maxNumberElem = document.getElementById('maxNumber');
+        const pathCanvas = document.getElementById('pathGraph');
+
+        let sequenceNumbers = [];
 
         let currentNumber = 0;
         let sequenceInterval = null;
@@ -389,6 +425,35 @@
             updateButtonStates();
             numberInput.disabled = false;
             console.log("Sequence ended:", reason);
+            updateStats();
+        }
+
+        function drawPathGraph(seq) {
+            const ctx = pathCanvas.getContext('2d');
+            ctx.clearRect(0, 0, pathCanvas.width, pathCanvas.height);
+            if (!seq.length) return;
+            const padding = 20;
+            const width = pathCanvas.width - padding * 2;
+            const height = pathCanvas.height - padding * 2;
+            const maxVal = Math.max(...seq);
+            ctx.beginPath();
+            seq.forEach((v, i) => {
+                const x = padding + (i / (seq.length - 1)) * width;
+                const y = padding + height - (v / maxVal) * height;
+                if (i === 0) ctx.moveTo(x, y);
+                else ctx.lineTo(x, y);
+            });
+            ctx.strokeStyle = '#61dafb';
+            ctx.lineWidth = 2;
+            ctx.stroke();
+        }
+
+        function updateStats() {
+            if (sequenceNumbers.length === 0) return;
+            totalStepsElem.textContent = `Total steps: ${sequenceNumbers.length - 1}`;
+            const maxVal = Math.max(...sequenceNumbers);
+            maxNumberElem.textContent = `Max number: ${maxVal}`;
+            drawPathGraph(sequenceNumbers);
         }
         
         function updateKnownNumbersDisplay() {
@@ -440,6 +505,7 @@
             }
             
             const { nextNum, operationTextDetail, originalNum } = performCollatzStep(currentNumber);
+            sequenceNumbers.push(nextNum);
             let explanation = `${originalNum} is ${originalNum % 2 === 0 ? 'even' : 'odd'}. Operation: ${operationTextDetail}`;
             
             addStepToOutput(nextNum, explanation, originalNum % 2 === 0, nextNum === 1);
@@ -453,6 +519,7 @@
             while (currentNumber !== 1 && maxIterations > 0) {
                 currentPathNumbers.push(currentNumber);
                 const { nextNum, operationTextDetail, originalNum } = performCollatzStep(currentNumber);
+                sequenceNumbers.push(nextNum);
                 let explanation = `${originalNum} is ${originalNum % 2 === 0 ? 'even' : 'odd'}. Operation: ${operationTextDetail}`;
                 
                 addStepToOutput(nextNum, explanation, originalNum % 2 === 0, nextNum === 1);
@@ -506,6 +573,11 @@
 
             currentNumber = startVal;
             isFastModeActive = startFast;
+
+            sequenceNumbers = [currentNumber];
+            totalStepsElem.textContent = 'Total steps: -';
+            maxNumberElem.textContent = 'Max number: -';
+            pathCanvas.getContext('2d').clearRect(0, 0, pathCanvas.width, pathCanvas.height);
 
             // Add starting number to path and display it
             addStepToOutput(currentNumber, `Starting with ${currentNumber}.`, currentNumber % 2 === 0, currentNumber === 1);


### PR DESCRIPTION
## Summary
- add `insight-card` styles for new statistics section
- show sequence stats and path graph under the output
- track sequence numbers to compute stats
- draw a simple canvas graph
- reset and update statistics when starting/ending sequences

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685e00563f2c832581cf0d44936d6732